### PR TITLE
(GH-123) Multi-Target .NET Core 3.1, 5 & 6 instead of .NET Standard 2.0

### DIFF
--- a/nuspec/nuget/Cake.Issues.PullRequests.GitHubActions.nuspec
+++ b/nuspec/nuget/Cake.Issues.PullRequests.GitHubActions.nuspec
@@ -26,8 +26,14 @@ See the Project Site for an overview of the whole ecosystem of addins for workin
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0\Cake.Issues.PullRequests.GitHubActions.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.PullRequests.GitHubActions.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.Issues.PullRequests.GitHubActions.xml" target="lib\netstandard2.0" />
+    <file src="netcoreapp3.1\Cake.Issues.PullRequests.GitHubActions.dll" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.PullRequests.GitHubActions.pdb" target="lib\netcoreapp3.1" />
+    <file src="netcoreapp3.1\Cake.Issues.PullRequests.GitHubActions.xml" target="lib\netcoreapp3.1" />
+    <file src="net5.0\Cake.Issues.PullRequests.GitHubActions.dll" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.PullRequests.GitHubActions.pdb" target="lib\net5.0" />
+    <file src="net5.0\Cake.Issues.PullRequests.GitHubActions.xml" target="lib\net5.0" />
+    <file src="net6.0\Cake.Issues.PullRequests.GitHubActions.dll" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.PullRequests.GitHubActions.pdb" target="lib\net6.0" />
+    <file src="net6.0\Cake.Issues.PullRequests.GitHubActions.xml" target="lib\net6.0" />
   </files>
 </package>

--- a/src/Cake.Issues.PullRequests.GitHubActions.Tests/Cake.Issues.PullRequests.GitHubActions.Tests.csproj
+++ b/src/Cake.Issues.PullRequests.GitHubActions.Tests/Cake.Issues.PullRequests.GitHubActions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <Product>Cake.Issues</Product>
     <Copyright>Copyright © Pascal Berger and contributors</Copyright>

--- a/src/Cake.Issues.PullRequests.GitHubActions/Cake.Issues.PullRequests.GitHubActions.csproj
+++ b/src/Cake.Issues.PullRequests.GitHubActions/Cake.Issues.PullRequests.GitHubActions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Description>Addin for writing code analyzer or linter issues to GitHub Actions</Description>
     <Authors>Pascal Berger</Authors>
     <Copyright>Copyright © Pascal Berger and contributors</Copyright>
@@ -12,14 +12,7 @@
     <DebugSymbols>true</DebugSymbols>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>..\Cake.Issues.PullRequests.GitHubActions.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Cake.Issues.PullRequests.GitHubActions.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Cake.Issues.PullRequests.GitHubActions.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Cake.Issues.PullRequests.GitHubActions.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Multi-Target .NET Core 3.1, 5, & 6 to follow best-practices for Cake 2.0.

Fixes #123 